### PR TITLE
Create a default PR template for the organization

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Description
+
+Add a description of what your PR will accomplish here.
+
+## Todos
+
+- [ ] Add todo items if there is still work to be done.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,12 @@
 ## Description
 
-Add a description of what your PR will accomplish here.
+Add a description of what your PR will accomplish here. Feel free to add multiple paragraphs, additional subheadings, lists, figures, links, etc. as necessary to adequately describe the PR using [GitHub Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
+
+## Related Issues/Pull Requests
+
+Take note of issues this PR may close if merged using [closing words](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) here. Also note any otherwise related issues and pull requests. Delete this section if there are none.
 
 ## Todos
 
-- [ ] Add todo items if there is still work to be done.
+- [ ] Add todo items here to indicate if there is still work to be done.
+- [ ] If there is a relevant label, use it!


### PR DESCRIPTION
## Description

It is useful to provide guidance and structure for someone making a pull request (PR), making it easier for them to know what information is expected. This PR adds a [PR template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) that becomes the default text in PR descriptions like this one. Since this is being created on the organization repository-level ([RxnRover/.github](https://github.com/RxnRover/.github)), it will be applied to all repos in the organization unless they override it with their own PR template file.

I modeled this PR description after the PR template structure for consistency and as the example of a fully completed PR description that would use the template. You can view the template rendered like this by going to the "Files changed" tab on this pull request > Click the three-dots (...) menu on the `.github/PULL_REQUEST_TEMPLATE.md` > Click "View file" from the menu dropdown. Swap between "Preview" and "Code" to see the rendered and plaintext versions.

I couldn't think of a reason to have multiple "types" of PR templates, so I created `.github/PULL_REQUEST_TEMPLATE.md` instead of the more complicated `.github/PULL_REQUEST_TEMPLATE/` subdirectory that allows for various PR template files in it. We can pretty easily expand to that later if needed, though.

## Related Issues/Pull Requests

There are no related issues or PRs.

## Todos

- [x] Add a section/reminder to mention other related issues or pull requests.
- [x] Add links to the GitHub documentation about PR templates in this description.