### PR TITLE
Add configurable input options to Python tox unit testing workflow

### DIFF
--- a/.github/workflows/python_unit_testing_tox_main.yml
+++ b/.github/workflows/python_unit_testing_tox_main.yml
@@ -1,27 +1,26 @@
-name: Unit Testing
+name: Python Unit Testing via Tox
 
 on:
   workflow_call:
-
+    inputs:
+      python:
+        required: false
+        type: string
+        default: "3.10"
+      platform:
+        required: false
+        type: string
+        default: "ubuntu-latest"
 
 jobs:
   test:
-    strategy:
-      matrix:
-        python:
-        - "3.9"  # oldest Python supported by PSF
-        - "3.11"  # newest Python that is stable
-        platform:
-        - ubuntu-latest
-        # - macos-latest
-        - windows-latest
-    runs-on: ${{ matrix.platform }}
+    runs-on: ${{ inputs.platform }}
     steps:
       - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ inputs.python }}
       
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Description

Right now, the workflow for Python unit testing via tox is hard-coded to use Python versions 3.9 and 3.11. Python 3.9 is reaching EOL soon and Python 3.12 and 3.13 have both been released as higher stable versions. Our reusable workflow needs to be more flexible to allow different projects to use it to test against different Python versions. Since it is the same pattern, I also made the test platforms configurable through an input value.

This is going to change the behavior of the workflow in any repos that currently refer to this workflow, so I have compiled a list of our repos that need to be updated. However, none of them are public at the moment, so please reach out if you need the list of repos to be converted.

## TODOs

- Double-check that this implementation works. It is hard to do this without creating an entire separate test organization, so I vote that we just merge it and fix issues as we see them.
