### PR TITLE
Update example automated tagging workflow to include master branch

### DIFF
--- a/.github/workflows/tag_version_and_release.yml
+++ b/.github/workflows/tag_version_and_release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - master
   pull_request:
     types:
       - labeled


### PR DESCRIPTION
## Description

Currently, the workflow for automatically tagging versions only accounts for a default branch named `main`, but many repositories under the organization still have the legacy default, `master`. While we should strive to update all of the default branch names to `main`, that is a longer endeavor. In the meantime, `RxnRover/.github/.github/workflows/tag_version_and_release.yml` serves as an example file when we apply the workflow to our repositories. Since it may be applied to repositories with either default branch name, I think it makes sense to update this file to avoid forgetting to update it when we copy over to certain repositories.